### PR TITLE
v0.12.0 compiler support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,12 +9,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-maybe": "^3.0.0",
-    "purescript-math": "^2.0.0"
+    "purescript-maybe": "^4.0.0",
+    "purescript-math": "^2.1.1"
   },
   "devDependencies": {
-    "purescript-quickcheck-laws": "^3.0.0",
-    "purescript-psci-support": "^3.0.0"
+    "purescript-quickcheck-laws": "paulyoung/purescript-quickcheck-laws#compiler/0.12",
+    "purescript-psci-support": "^4.0.0"
   },
   "license": "MIT",
   "repository": {

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,10 +2,7 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE)
-import Control.Monad.Eff.Exception (EXCEPTION)
-import Control.Monad.Eff.Random (RANDOM)
+import Effect (Effect)
 import Data.UInt (UInt, fromNumber)
 import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary)
 import Test.QuickCheck.Laws.Data as Data
@@ -24,7 +21,7 @@ derive newtype instance commutativeRingTestUInt :: CommutativeRing TestUInt
 derive newtype instance euclideanRingTestUInt :: EuclideanRing TestUInt
 
 
-main :: forall e. Eff (exception :: EXCEPTION, random :: RANDOM, console :: CONSOLE | e) Unit
+main :: Effect Unit
 main = do
   let prxUInt = Proxy ∷ Proxy TestUInt
   Data.checkEq prxUInt


### PR DESCRIPTION
devDependencies dependent on [garyb/purescript-quickcheck-laws#39](https://github.com/garyb/purescript-quickcheck-laws/pull/39) but otherwise this is ready to merge and release.