### PR TITLE
Bugfix - use imul for big numbers

### DIFF
--- a/src/Data/UInt.js
+++ b/src/Data/UInt.js
@@ -34,7 +34,7 @@ exports.uintAdd = function (x) {
 
 exports.uintMul = function (x) {
     return function (y) {
-        return (x * y) >>> 0;
+        return Math.imul(x, y) >>> 0;
     };
 };
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,8 +3,9 @@ module Test.Main where
 import Prelude
 
 import Effect (Effect)
-import Data.UInt (UInt, fromNumber)
+import Data.UInt (UInt, fromInt, fromNumber)
 import Data.UInt.Gen (genUInt)
+import Test.QuickCheck (quickCheck, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws.Data as Data
 import Type.Proxy (Proxy(..))
@@ -22,7 +23,6 @@ derive newtype instance ringTestUInt :: Ring TestUInt
 derive newtype instance commutativeRingTestUInt :: CommutativeRing TestUInt
 derive newtype instance euclideanRingTestUInt :: EuclideanRing TestUInt
 
-
 main :: Effect Unit
 main = do
   let prxUInt = Proxy ∷ Proxy TestUInt
@@ -33,3 +33,11 @@ main = do
   Data.checkEuclideanRing prxUInt
   Data.checkBounded prxUInt
   Data.checkCommutativeRing prxUInt
+  mulRegression1
+
+mulRegression1 :: Effect Unit
+mulRegression1 = do
+  let lhs = fromInt (-2047875787)
+      rhs = fromInt (-1028477387)
+      expected = fromInt 1364097529
+  quickCheck $ lhs * rhs === expected

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,7 +3,7 @@ module Test.Main where
 import Prelude
 
 import Effect (Effect)
-import Data.UInt (UInt, fromInt, fromNumber)
+import Data.UInt (UInt, and, fromInt, fromNumber)
 import Data.UInt.Gen (genUInt)
 import Test.QuickCheck (quickCheck, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
@@ -33,7 +33,14 @@ main = do
   Data.checkEuclideanRing prxUInt
   Data.checkBounded prxUInt
   Data.checkCommutativeRing prxUInt
+  checkMulIsPrecise
   mulRegression1
+
+checkMulIsPrecise :: Effect Unit
+checkMulIsPrecise = do
+  let onlyLowBits = and (fromInt 0x1)
+  quickCheck \lhs rhs ->
+    onlyLowBits (lhs * rhs) === onlyLowBits lhs * onlyLowBits rhs
 
 mulRegression1 :: Effect Unit
 mulRegression1 = do


### PR DESCRIPTION
Hi, thanks for `Data.UInt`.

I think I found a bug where UInt's `mul` doesn't do precise multiplication for big integers. I guess that `*` encourages the JavaScript runtime to do floating point multiplication, and so some precision is lost. It seems that in this situation developers are recommended to use `Math.imul` for precise integer multiplication. Observe the following node.js session:

```
> lhs = (-2047875787) >>> 0;
2247091509
> rhs = (-1028477387) >>> 0;
3266489909
> (lhs * rhs) >>> 0
1364097024
> Math.imul(lhs, rhs)
1364097529
```

I didn't know `*` did this either, credit for the workaround I've supplied goes to stack overflow: https://stackoverflow.com/questions/6232939/is-there-a-way-to-correctly-multiply-two-32-bit-integers-in-javascript

I also added a regression test for this to your test suite as well (but couldn't think of a cool quickcheck prpoperty). Please let me know if there's anything else I can do to help get this merged :smile: 