### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -38,3 +40,6 @@ jobs:
 
       - name: Run tests
         run: spago -x test.dhall test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/src/Data/UInt.purs
+++ b/src/Data/UInt.purs
@@ -1,28 +1,31 @@
 module Data.UInt
-     ( UInt
-     , fromInt
-     , fromInt'
-     , toInt
-     , toInt'
-     , fromNumber
-     , fromNumber'
-     , toNumber
-     , floor
-     , ceil
-     , round
-     , even
-     , odd
-     , pow
-     , and, (.&.)
-     , or, (.|.)
-     , xor, (.^.)
-     , shl
-     , shr
-     , zshr
-     , complement
-     , toString
-     , fromString
-     ) where
+  ( UInt
+  , fromInt
+  , fromInt'
+  , toInt
+  , toInt'
+  , fromNumber
+  , fromNumber'
+  , toNumber
+  , floor
+  , ceil
+  , round
+  , even
+  , odd
+  , pow
+  , and
+  , (.&.)
+  , or
+  , (.|.)
+  , xor
+  , (.^.)
+  , shl
+  , shr
+  , zshr
+  , complement
+  , toString
+  , fromString
+  ) where
 
 import Data.Maybe (Maybe(..))
 import Data.Semiring (class Semiring)
@@ -38,7 +41,6 @@ import Data.Semigroup ((<>))
 import Data.Enum (class Enum)
 import Prelude ((<), (>), (+), (-))
 import Math (ceil, floor, round) as Math
-
 
 -- | 32-bit unsigned integer. Range from *0* to *4294967295*.
 newtype UInt = UInt Number

--- a/src/Data/UInt/Gen.purs
+++ b/src/Data/UInt/Gen.purs
@@ -4,7 +4,6 @@ import Prelude ((<$>))
 import Data.UInt (UInt, fromNumber, toNumber)
 import Control.Monad.Gen.Class (class MonadGen, chooseFloat)
 
-
 genUInt :: forall m. MonadGen m => UInt -> UInt -> m UInt
 genUInt a b = fromNumber <$> chooseFloat (toNumber a) (toNumber b)
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -16,6 +16,7 @@ newtype TestUInt = TestUInt UInt
 instance newtypeTestUInt :: Newtype TestUInt UInt
 instance arbitraryTestUInt :: Arbitrary TestUInt where
   arbitrary = TestUInt <$> genUInt bottom (fromNumber 20000.0)
+
 derive newtype instance boundedTestUInt :: Bounded TestUInt
 derive newtype instance eqTestUInt :: Eq TestUInt
 derive newtype instance ordTestUInt :: Ord TestUInt
@@ -27,7 +28,7 @@ derive newtype instance euclideanRingTestUInt :: EuclideanRing TestUInt
 
 main :: Effect Unit
 main = do
-  let prxUInt = Proxy ∷ Proxy TestUInt
+  let prxUInt = Proxy :: Proxy TestUInt
   Data.checkEq prxUInt
   Data.checkOrd prxUInt
   Data.checkSemiring prxUInt
@@ -40,14 +41,16 @@ main = do
 
 checkMulIsPrecise :: Effect Unit
 checkMulIsPrecise = do
-  let onlyLowBits :: TestUInt -> TestUInt
-      onlyLowBits = over TestUInt $ and $ fromInt 0x1
+  let
+    onlyLowBits :: TestUInt -> TestUInt
+    onlyLowBits = over TestUInt $ and $ fromInt 0x1
   quickCheck \lhs rhs ->
     onlyLowBits (lhs * rhs) === onlyLowBits lhs * onlyLowBits rhs
 
 mulRegression1 :: Effect Unit
 mulRegression1 = do
-  let lhs = fromInt (-2047875787)
-      rhs = fromInt (-1028477387)
-      expected = fromInt 1364097529
+  let
+    lhs = fromInt (-2047875787)
+    rhs = fromInt (-1028477387)
+    expected = fromInt 1364097529
   quickCheck $ lhs * rhs === expected


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
